### PR TITLE
[ENHANCEMENT] Base Models

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
-    "test:e2e": "jest --config ./test/jest-e2e.json"
+    "test:e2e": "jest --config ./test/jest-e2e.json",
+    "typeorm": "ts-node ./node_modules/typeorm/cli.js"
   },
   "dependencies": {
     "@nestjs/common": "^7.5.1",

--- a/src/database/migrations/1611573478283-UserModel.ts
+++ b/src/database/migrations/1611573478283-UserModel.ts
@@ -1,0 +1,55 @@
+import { MigrationInterface, QueryRunner, Table } from "typeorm";
+
+export class UserModel1611573478283 implements MigrationInterface {
+  name = "UserModel1611573478283";
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.createTable(
+      new Table({
+        name: "user",
+        columns: [
+          {
+            name: "id",
+            type: "int",
+            isPrimary: true,
+          },
+          {
+            name: "username",
+            type: "varchar",
+            isNullable: false,
+          },
+          {
+            name: "password",
+            type: "varchar",
+            isNullable: false,
+          },
+          {
+            name: "first_name",
+            type: "varchar",
+            isNullable: false,
+          },
+          {
+            name: "last_name",
+            type: "varchar",
+            isNullable: false,
+          },
+          {
+            name: "created_at",
+            type: "timestamp",
+            default: "now()",
+          },
+          {
+            name: "updated_at",
+            type: "timestamp",
+            default: "now()",
+          },
+        ],
+      }),
+      true,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropTable("user");
+  }
+}

--- a/src/database/migrations/1611603797240-PostModel.ts
+++ b/src/database/migrations/1611603797240-PostModel.ts
@@ -1,0 +1,42 @@
+import { MigrationInterface, QueryRunner, Table } from "typeorm";
+
+export class PostModel1611603797240 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.createTable(
+      new Table({
+        name: "posts",
+        columns: [
+          {
+            name: "id",
+            type: "int",
+            isPrimary: true,
+          },
+          {
+            name: "title",
+            type: "varchar",
+            isNullable: false,
+          },
+          {
+            name: "body",
+            type: "varchar",
+            isNullable: false,
+          },
+          {
+            name: "created_at",
+            type: "timestamp",
+            default: "now()",
+          },
+          {
+            name: "updated_at",
+            type: "timestamp",
+            default: "now()",
+          },
+        ],
+      }),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropTable("posts");
+  }
+}

--- a/src/database/migrations/1611603990682-UserModelTableNameUpdate.ts
+++ b/src/database/migrations/1611603990682-UserModelTableNameUpdate.ts
@@ -1,0 +1,98 @@
+import { MigrationInterface, QueryRunner, Table } from "typeorm";
+
+export class UserModelTableNameUpdate1611603990682
+  implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropTable("user");
+    await queryRunner.createTable(
+      new Table({
+        name: "users",
+        columns: [
+          {
+            name: "id",
+            type: "int",
+            isPrimary: true,
+          },
+          {
+            name: "username",
+            type: "varchar",
+            isNullable: false,
+          },
+          {
+            name: "password",
+            type: "varchar",
+            isNullable: false,
+          },
+          {
+            name: "first_name",
+            type: "varchar",
+            isNullable: false,
+          },
+          {
+            name: "last_name",
+            type: "varchar",
+            isNullable: false,
+          },
+          {
+            name: "created_at",
+            type: "timestamp",
+            default: "now()",
+          },
+          {
+            name: "updated_at",
+            type: "timestamp",
+            default: "now()",
+          },
+        ],
+      }),
+      true,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropTable("users");
+    await queryRunner.createTable(
+      new Table({
+        name: "user",
+        columns: [
+          {
+            name: "id",
+            type: "int",
+            isPrimary: true,
+          },
+          {
+            name: "username",
+            type: "varchar",
+            isNullable: false,
+          },
+          {
+            name: "password",
+            type: "varchar",
+            isNullable: false,
+          },
+          {
+            name: "first_name",
+            type: "varchar",
+            isNullable: false,
+          },
+          {
+            name: "last_name",
+            type: "varchar",
+            isNullable: false,
+          },
+          {
+            name: "created_at",
+            type: "timestamp",
+            default: "now()",
+          },
+          {
+            name: "updated_at",
+            type: "timestamp",
+            default: "now()",
+          },
+        ],
+      }),
+      true,
+    );
+  }
+}

--- a/src/database/migrations/1611604238246-PostAuthor.ts
+++ b/src/database/migrations/1611604238246-PostAuthor.ts
@@ -1,0 +1,35 @@
+import {
+  MigrationInterface,
+  QueryRunner,
+  TableColumn,
+  TableForeignKey,
+} from "typeorm";
+
+export class PostAuthor1611604238246 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.addColumn(
+      "posts",
+      new TableColumn({
+        name: "author_id",
+        type: "int",
+        isNullable: false,
+      }),
+    );
+
+    const foreignKey = new TableForeignKey({
+      columnNames: ["author_id"],
+      referencedColumnNames: ["id"],
+      referencedTableName: "users",
+      onDelete: "CASCADE",
+    });
+    await queryRunner.createForeignKey("posts", foreignKey);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    const table = await queryRunner.getTable("posts");
+    const foreignKey = table.foreignKeys.find((key) =>
+      key.columnNames.includes("author_id"),
+    );
+    await queryRunner.dropForeignKey(table, foreignKey);
+  }
+}

--- a/src/database/migrations/1611612155643-FlairModel.ts
+++ b/src/database/migrations/1611612155643-FlairModel.ts
@@ -1,0 +1,42 @@
+import { MigrationInterface, QueryRunner, Table } from "typeorm";
+
+export class FlairModel1611612155643 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.createTable(
+      new Table({
+        name: "flairs",
+        columns: [
+          {
+            name: "id",
+            type: "int",
+            isPrimary: true,
+          },
+          {
+            name: "value",
+            type: "varchar",
+            isNullable: false,
+          },
+          {
+            name: "color",
+            type: "varchar",
+            isNullable: false,
+          },
+          {
+            name: "created_at",
+            type: "timestamp",
+            default: "now()",
+          },
+          {
+            name: "updated_at",
+            type: "timestamp",
+            default: "now()",
+          },
+        ],
+      }),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropTable("flairs");
+  }
+}

--- a/src/database/migrations/1611613282250-PostToFlair.ts
+++ b/src/database/migrations/1611613282250-PostToFlair.ts
@@ -1,0 +1,61 @@
+import {
+  MigrationInterface,
+  QueryRunner,
+  Table,
+  TableForeignKey,
+} from "typeorm";
+
+export class PostToFlair1611613282250 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.createTable(
+      new Table({
+        name: "posts_flairs",
+        columns: [
+          {
+            name: "id",
+            type: "int",
+            isPrimary: true,
+          },
+          {
+            name: "post_id",
+            type: "int",
+            isNullable: false,
+          },
+          {
+            name: "flair_id",
+            type: "int",
+            isNullable: false,
+          },
+          {
+            name: "created_at",
+            type: "timestamp",
+            default: "now()",
+          },
+          {
+            name: "updated_at",
+            type: "timestamp",
+            default: "now()",
+          },
+        ],
+      }),
+    );
+
+    const postForeignKey = new TableForeignKey({
+      columnNames: ["post_id"],
+      referencedColumnNames: ["id"],
+      referencedTableName: "posts",
+    });
+    await queryRunner.createForeignKey("posts_flairs", postForeignKey);
+
+    const flairForeignKey = new TableForeignKey({
+      columnNames: ["flair_id"],
+      referencedColumnNames: ["id"],
+      referencedTableName: "flairs",
+    });
+    await queryRunner.createForeignKey("posts_flairs", flairForeignKey);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropTable("posts_flairs");
+  }
+}

--- a/src/flairs/flair.entity.ts
+++ b/src/flairs/flair.entity.ts
@@ -20,7 +20,7 @@ export class Flair {
   color: string;
 
   @OneToMany(() => PostToFlair, (postToFlair) => postToFlair.flair)
-  public postToFlairs: PostToFlair[];
+  postToFlairs: PostToFlair[];
 
   @CreateDateColumn({ name: "created_at" })
   createdAt: Date;

--- a/src/flairs/flair.entity.ts
+++ b/src/flairs/flair.entity.ts
@@ -1,0 +1,25 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+} from "typeorm";
+
+@Entity({ name: "flairs" })
+export class Flair {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column()
+  value: string;
+
+  @Column()
+  color: string;
+
+  @CreateDateColumn({ name: "created_at" })
+  createdAt: Date;
+
+  @UpdateDateColumn({ name: "updated_at" })
+  updatedAt: Date;
+}

--- a/src/flairs/flair.entity.ts
+++ b/src/flairs/flair.entity.ts
@@ -1,7 +1,9 @@
+import { PostToFlair } from "src/posts/postToFlair.entity";
 import {
   Column,
   CreateDateColumn,
   Entity,
+  OneToMany,
   PrimaryGeneratedColumn,
   UpdateDateColumn,
 } from "typeorm";
@@ -16,6 +18,9 @@ export class Flair {
 
   @Column()
   color: string;
+
+  @OneToMany(() => PostToFlair, (postToFlair) => postToFlair.flair)
+  public postToFlairs: PostToFlair[];
 
   @CreateDateColumn({ name: "created_at" })
   createdAt: Date;

--- a/src/posts/post.entity.ts
+++ b/src/posts/post.entity.ts
@@ -27,7 +27,7 @@ export class Post {
   author: User;
 
   @OneToMany(() => PostToFlair, (postToFlair) => postToFlair.post)
-  public postToFlairs: PostToFlair[];
+  postToFlairs: PostToFlair[];
 
   @CreateDateColumn({ name: "created_at" })
   createdAt: Date;

--- a/src/posts/post.entity.ts
+++ b/src/posts/post.entity.ts
@@ -1,13 +1,15 @@
 import { User } from "src/users/user.entity";
 import {
-  Entity,
   Column,
-  PrimaryGeneratedColumn,
   CreateDateColumn,
-  UpdateDateColumn,
-  ManyToOne,
+  Entity,
   JoinColumn,
+  ManyToOne,
+  OneToMany,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
 } from "typeorm";
+import { PostToFlair } from "./postToFlair.entity";
 
 @Entity({ name: "posts" })
 export class Post {
@@ -23,6 +25,9 @@ export class Post {
   @ManyToOne(() => User, (user) => user.posts, { onDelete: "CASCADE" })
   @JoinColumn({ name: "author_id" })
   author: User;
+
+  @OneToMany(() => PostToFlair, (postToFlair) => postToFlair.post)
+  public postToFlairs: PostToFlair[];
 
   @CreateDateColumn({ name: "created_at" })
   createdAt: Date;

--- a/src/posts/post.entity.ts
+++ b/src/posts/post.entity.ts
@@ -1,9 +1,12 @@
+import { User } from "src/users/user.entity";
 import {
   Entity,
   Column,
   PrimaryGeneratedColumn,
   CreateDateColumn,
   UpdateDateColumn,
+  ManyToOne,
+  JoinColumn,
 } from "typeorm";
 
 @Entity({ name: "posts" })
@@ -16,6 +19,10 @@ export class Post {
 
   @Column()
   body: string;
+
+  @ManyToOne(() => User, (user) => user.posts, { onDelete: "CASCADE" })
+  @JoinColumn({ name: "author_id" })
+  author: User;
 
   @CreateDateColumn({ name: "created_at" })
   createdAt: Date;

--- a/src/posts/post.entity.ts
+++ b/src/posts/post.entity.ts
@@ -6,8 +6,8 @@ import {
   UpdateDateColumn,
 } from "typeorm";
 
-@Entity({ name: "users" })
-export class User {
+@Entity({ name: "posts" })
+export class Post {
   @PrimaryGeneratedColumn()
   id: number;
 

--- a/src/posts/post.entity.ts
+++ b/src/posts/post.entity.ts
@@ -1,0 +1,25 @@
+import {
+  Entity,
+  Column,
+  PrimaryGeneratedColumn,
+  CreateDateColumn,
+  UpdateDateColumn,
+} from "typeorm";
+
+@Entity({ name: "users" })
+export class User {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column()
+  title: string;
+
+  @Column()
+  body: string;
+
+  @CreateDateColumn({ name: "created_at" })
+  createdAt: Date;
+
+  @UpdateDateColumn({ name: "updated_at" })
+  updatedAt: Date;
+}

--- a/src/posts/postToFlair.entity.ts
+++ b/src/posts/postToFlair.entity.ts
@@ -1,0 +1,30 @@
+import { Flair } from "src/flairs/flair.entity";
+import {
+  CreateDateColumn,
+  Entity,
+  JoinColumn,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+} from "typeorm";
+import { Post } from "./post.entity";
+
+@Entity({ name: "posts_flairs" })
+export class PostToFlair {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @ManyToOne(() => Post, (post) => post.postToFlairs)
+  @JoinColumn({ name: "post_id" })
+  public post: Post;
+
+  @ManyToOne(() => Flair, (flair) => flair.postToFlairs)
+  @JoinColumn({ name: "flair_id" })
+  public flair: Flair;
+
+  @CreateDateColumn({ name: "created_at" })
+  createdAt: Date;
+
+  @UpdateDateColumn({ name: "updated_at" })
+  updatedAt: Date;
+}

--- a/src/posts/postToFlair.entity.ts
+++ b/src/posts/postToFlair.entity.ts
@@ -16,11 +16,11 @@ export class PostToFlair {
 
   @ManyToOne(() => Post, (post) => post.postToFlairs)
   @JoinColumn({ name: "post_id" })
-  public post: Post;
+  post: Post;
 
   @ManyToOne(() => Flair, (flair) => flair.postToFlairs)
   @JoinColumn({ name: "flair_id" })
-  public flair: Flair;
+  flair: Flair;
 
   @CreateDateColumn({ name: "created_at" })
   createdAt: Date;

--- a/src/users/user.entity.ts
+++ b/src/users/user.entity.ts
@@ -6,7 +6,7 @@ import {
   UpdateDateColumn,
 } from "typeorm";
 
-@Entity()
+@Entity({ name: "users" })
 export class User {
   @PrimaryGeneratedColumn()
   id: number;

--- a/src/users/user.entity.ts
+++ b/src/users/user.entity.ts
@@ -1,0 +1,31 @@
+import {
+  Entity,
+  Column,
+  PrimaryGeneratedColumn,
+  CreateDateColumn,
+  UpdateDateColumn,
+} from "typeorm";
+
+@Entity()
+export class User {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column()
+  username: string;
+
+  @Column()
+  password: string;
+
+  @Column({ name: "first_name" })
+  firstName: string;
+
+  @Column({ name: "last_name" })
+  lastName: string;
+
+  @CreateDateColumn({ name: "created_at" })
+  createdAt: Date;
+
+  @UpdateDateColumn({ name: "updated_at" })
+  updatedAt: Date;
+}

--- a/src/users/user.entity.ts
+++ b/src/users/user.entity.ts
@@ -1,9 +1,11 @@
+import { Post } from "../posts/post.entity";
 import {
   Entity,
   Column,
   PrimaryGeneratedColumn,
   CreateDateColumn,
   UpdateDateColumn,
+  OneToMany,
 } from "typeorm";
 
 @Entity({ name: "users" })
@@ -22,6 +24,9 @@ export class User {
 
   @Column({ name: "last_name" })
   lastName: string;
+
+  @OneToMany(() => Post, (post) => post.author, { cascade: true })
+  posts: Post[];
 
   @CreateDateColumn({ name: "created_at" })
   createdAt: Date;


### PR DESCRIPTION
Create base models required by the core functionality of Recog; users, posts, and flairs.

This commit includes TypeORM migrations which can be ran using `yarn typeorm migration:run`, using the `yarn` script allows TypeORM to use Typescript instead of pure Js.

# Model Overview

## `User`

The base user model is currently setup with the default username/password combination, which may change in the future depending on authentication flows.

Also contains a relationship to posts using the `author_id` attribute on `Post`, see more below.

## `Post`

The `Post` entity represents simple posts with a title, markdown body and meta fields, such as `author` corresponding to the `User` model which created the post, and a many-to-many relationship to the `Flair` entity, see more below.

## `Flair`

`Flair`s are used to group posts, the entity contains fields for `value` and `color`, with a many-to-many relationship to `Post`s using a join table, and a custom entity to map IDs, `PostToFlair`.