### PR TITLE
[ENHANCEMENT] Mapped Types / Access Token Expires At

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "faker": "^5.4.0",
     "graphql": "^15.4.0",
     "graphql-tools": "^7.0.2",
+    "ms": "^2.1.3",
     "mysql": "^2.18.1",
     "passport": "^0.4.1",
     "passport-jwt": "^4.0.0",

--- a/schema.gql
+++ b/schema.gql
@@ -35,17 +35,25 @@ type User {
 type LoginUserPayload {
   user: User!
   accessToken: String!
+  accessTokenExpiresAt: DateTime!
   refreshToken: String!
 }
+
+"""
+A date-time string at UTC, such as 2019-12-03T09:54:33Z, compliant with the date-time format.
+"""
+scalar DateTime
 
 type RefreshTokenPayload {
   user: User!
   accessToken: String!
+  accessTokenExpiresAt: DateTime!
 }
 
 type RegisterUserPayload {
   user: User!
   accessToken: String!
+  accessTokenExpiresAt: DateTime!
   refreshToken: String!
 }
 

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -19,7 +19,9 @@ import { RefreshToken } from "./refresh-token.entity";
       imports: [ConfigModule],
       useFactory: async (configService: ConfigService) => ({
         secret: configService.get<string>("auth.jwtKey"),
-        signOptions: { expiresIn: "15m" },
+        signOptions: {
+          expiresIn: configService.get<number>("auth.jwtKeyExpiresIn"),
+        },
       }),
       inject: [ConfigService],
     }),

--- a/src/auth/dto/login-user.payload.ts
+++ b/src/auth/dto/login-user.payload.ts
@@ -11,5 +11,8 @@ export class LoginUserPayload {
   accessToken: string;
 
   @Field()
+  accessTokenExpiresAt: Date;
+
+  @Field()
   refreshToken: string;
 }

--- a/src/auth/dto/refresh-token.payload.ts
+++ b/src/auth/dto/refresh-token.payload.ts
@@ -1,12 +1,7 @@
-import { Field, ObjectType } from "@nestjs/graphql";
-import { UserObject } from "../../users/dto/user.object";
-import { User } from "../../users/entities/user.entity";
+import { ObjectType, OmitType } from "@nestjs/graphql";
+import { LoginUserPayload } from "./login-user.payload";
 
 @ObjectType()
-export class RefreshTokenPayload {
-  @Field(() => UserObject)
-  user: User;
-
-  @Field()
-  accessToken: string;
-}
+export class RefreshTokenPayload extends OmitType(LoginUserPayload, [
+  "refreshToken",
+] as const) {}

--- a/src/auth/dto/register-user.payload.ts
+++ b/src/auth/dto/register-user.payload.ts
@@ -1,15 +1,5 @@
-import { Field, ObjectType } from "@nestjs/graphql";
-import { UserObject } from "../../users/dto/user.object";
-import { User } from "../../users/entities/user.entity";
+import { ObjectType } from "@nestjs/graphql";
+import { LoginUserPayload } from "./login-user.payload";
 
 @ObjectType()
-export class RegisterUserPayload {
-  @Field(() => UserObject)
-  user: User;
-
-  @Field()
-  accessToken: string;
-
-  @Field()
-  refreshToken: string;
-}
+export class RegisterUserPayload extends LoginUserPayload {}

--- a/src/config/configuration.ts
+++ b/src/config/configuration.ts
@@ -1,6 +1,14 @@
-export default () => ({
-  port: parseInt(process.env.PORT, 10) || 3000,
-  auth: {
-    jwtKey: process.env.JWT_KEY,
-  },
-});
+import * as ms from "ms";
+
+export default () => {
+  const _jwtKeyExpiresIn = process.env.JWT_EXPIRES_IN || "15m";
+  const jwtKeyExpiresIn = ms(_jwtKeyExpiresIn) / 1000;
+
+  return {
+    port: parseInt(process.env.PORT, 10) || 3000,
+    auth: {
+      jwtKey: process.env.JWT_KEY,
+      jwtKeyExpiresIn,
+    },
+  };
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -6386,7 +6386,7 @@ ms@2.1.2:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
 
-ms@^2.0.0, ms@^2.1.1:
+ms@^2.0.0, ms@^2.1.1, ms@^2.1.3:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==


### PR DESCRIPTION
# Overview 

Use NestJS mapped types to generate GraphQL payload schemas and types, and add `accessTokenExpiresAt` field to login/sign up and refresh token payloads.

## Other

 - Add `jwtKeyExpiresIn` seconds value to `configuration.ts` for central management.
 - Check fields of GQL mutation request to only calculate access and refresh token, as well as date fields if required.